### PR TITLE
Add RtfTree.LoadRtfFile overload that takes encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.suo
 *.user
 *.sln.docstates
+*.userprefs
 
 # Build results
 [Dd]ebug/

--- a/nrtftree-examples/simple-demo/simple-demo.csproj
+++ b/nrtftree-examples/simple-demo/simple-demo.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>simple_demo</RootNamespace>
     <AssemblyName>simple-demo</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/nrtftree-library/RtfTree.cs
+++ b/nrtftree-library/RtfTree.cs
@@ -116,11 +116,23 @@ namespace Net.Sgoliver.NRtfTree
             /// En caso contrario se devuelve el valor -1.</returns>
             public int LoadRtfFile(string path)
             {
+                return LoadRtfFile(path, Encoding.Default);
+            }
+
+            /// <summary>
+            /// Carga un fichero en formato RTF.
+            /// </summary>
+            /// <param name="path">Ruta del fichero con el documento.</param>
+            /// <param name="encoding"></param>
+            /// <returns>Se devuelve el valor 0 en caso de no producirse ningún error en la carga del documento.
+            /// En caso contrario se devuelve el valor -1.</returns>
+            public int LoadRtfFile(string path, Encoding encoding)
+            {
                 //Resultado de la carga
                 int res = 0;
 
                 //Se abre el fichero de entrada
-                rtf = new StreamReader(path);
+                rtf = new StreamReader(path, encoding);
 
                 //Se crea el analizador léxico para RTF
                 lex = new RtfLex(rtf);

--- a/nrtftree-library/nrtftree-library.csproj
+++ b/nrtftree-library/nrtftree-library.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nrtftree_library</RootNamespace>
     <AssemblyName>nrtftree-library</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/nrtftree-test/nrtftree-test.csproj
+++ b/nrtftree-test/nrtftree-test.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nrtftree_test</RootNamespace>
     <AssemblyName>nrtftree-test</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
On Linux the default encoding is UTF-8, so it makes life easier to have a LoadRtfFile method that takes an encoding parameter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sgolivernet/nrtftree/16)

<!-- Reviewable:end -->
