### PR TITLE
Add Text highlight support

### DIFF
--- a/nrtftree-examples/simple-demo/app.config
+++ b/nrtftree-examples/simple-demo/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/nrtftree-examples/simple-demo/simple-demo.csproj
+++ b/nrtftree-examples/simple-demo/simple-demo.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>simple_demo</RootNamespace>
     <AssemblyName>simple-demo</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/nrtftree-library/Properties/AssemblyInfo.cs
+++ b/nrtftree-library/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0")]
-[assembly: AssemblyFileVersion("0.4.0")]
+[assembly: AssemblyVersion("0.4.0.1")]
+[assembly: AssemblyFileVersion("0.4.0.1")]

--- a/nrtftree-library/nrtftree-library.csproj
+++ b/nrtftree-library/nrtftree-library.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nrtftree_library</RootNamespace>
     <AssemblyName>nrtftree-library</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/nrtftree-test/nrtftree-test.csproj
+++ b/nrtftree-test/nrtftree-test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nrtftree_test</RootNamespace>
     <AssemblyName>nrtftree-test</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
I needed the ability to highlight certain blocks of text so I went ahead and added highlight support based on version 0.4.0.

I first tried adding support for setting a background color but that didn't seem to work when the file was rendered in Microsoft Word. The challenge with highlighting is that there's no end tag so any text that's added with a highlight must be wrapped in a group. The code I wrote automatically adds that group. While highlighting in the Rtf spec technically allows different colors to be used I only implemented a stock yellow highlight.

Because I used default parameters (a feature of .NET 4) I had to switch the target version from 2.0 to 4.0